### PR TITLE
fixes

### DIFF
--- a/scenarios/mnist/ci/Dockerfile.mnist_2
+++ b/scenarios/mnist/ci/Dockerfile.mnist_2
@@ -11,4 +11,4 @@ RUN pip3 install pyspark pandas
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/
 RUN export JAVA_HOME
 
-COPY ccr_depa_covid_poc_dp_data_prep_index.py ccr_depa_covid_poc_dp_data_prep_index.py 
+COPY ccr_depa_covid_poc_dp_data_prep_mnist_2.py ccr_depa_covid_poc_dp_data_prep_mnist_2.py 

--- a/scenarios/mnist/ci/Dockerfile.mnist_3
+++ b/scenarios/mnist/ci/Dockerfile.mnist_3
@@ -11,4 +11,4 @@ RUN pip3 install pyspark pandas
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/
 RUN export JAVA_HOME
 
-COPY ccr_depa_covid_poc_dp_data_prep_icmr.py ccr_depa_covid_poc_dp_data_prep_icmr.py 
+COPY ccr_depa_covid_poc_dp_data_prep_mnist_3.py ccr_depa_covid_poc_dp_data_prep_mnist_3.py 

--- a/scenarios/mnist/config/query_config.json
+++ b/scenarios/mnist/config/query_config.json
@@ -2,7 +2,7 @@
    "datasets": [
       {
          "id": "19517ba8-bab8-11ed-afa1-0242ac120002",
-         "name": "mnist_1",
+         "name": "dp_mnist_1_standardised_anon",
          "file": "dp_mnist_1_standardised_anon.csv",
          "select_variables": [
 
@@ -11,7 +11,7 @@
       },
       {
          "id": "216d5cc6-bab8-11ed-afa1-0242ac120002",
-         "name": "mnist_2",
+         "name": "dp_mnist_2_standardised_anon",
          "file": "dp_mnist_2_standardised_anon.csv",
          "select_variables": [
 
@@ -20,7 +20,7 @@
       },
       {
          "id": "2830a144-bab8-11ed-afa1-0242ac120002",
-         "name": "mnist_3",
+         "name": "dp_mnist_3_standardised_anon",
          "file": "dp_mnist_3_standardised_anon.csv",
          "select_variables": [
 
@@ -29,7 +29,7 @@
       }
    ],
    "joined_dataset": {
-      "joined_dataset": "dp_mnist_1_standardised_anon.csv",
+      "joined_dataset": "sandbox_mnist_without_key_identifiers.csv",
       "joining_query": "SELECT * FROM dp_mnist_1_standardised_anon UNION SELECT * FROM dp_mnist_2_standardised_anon UNION SELECT * FROM dp_mnist_3_standardised_anon",
       "joining_key": "",
       "model_output_folder": "/tmp/",

--- a/scenarios/mnist/deployment/docker/docker-compose-modelsave.yml
+++ b/scenarios/mnist/deployment/docker/docker-compose-modelsave.yml
@@ -1,6 +1,6 @@
 services:
   model_save:
-    image: ${CONTAINER_REGISTRY}/ccr-model-save:latest
+    image: ${CONTAINER_REGISTRY:+$CONTAINER_REGISTRY/}ccr-model-save:latest
     volumes:
       - $MODEL_OUTPUT_PATH:/mnt/model
     command: ["python3.9", "ccr_dpsgd_model_saving_template_v2.py"]

--- a/scenarios/mnist/deployment/docker/docker-compose-preprocess.yml
+++ b/scenarios/mnist/deployment/docker/docker-compose-preprocess.yml
@@ -1,18 +1,18 @@
 services:
   mnist_1:
-    image: ${CONTAINER_REGISTRY}/preprocess-mnist_1:latest
+    image: ${CONTAINER_REGISTRY:+$CONTAINER_REGISTRY/}preprocess-mnist_1:latest
     volumes:
       - $MNIST_1_INPUT_PATH:/mnt/depa_ccr_poc/data
       - $MNIST_1_OUTPUT_PATH:/mnt/output/mnist_1
     command: ["python3", "ccr_depa_covid_poc_dp_data_prep_mnist_1.py"]
   mnist_2:
-    image: ${CONTAINER_REGISTRY}/preprocess-mnist_2:latest
+    image: ${CONTAINER_REGISTRY:+$CONTAINER_REGISTRY/}preprocess-mnist_2:latest
     volumes:
       - $MNIST_2_INPUT_PATH:/mnt/depa_ccr_poc/data
       - $MNIST_2_OUTPUT_PATH:/mnt/output/mnist_2
     command: ["python3", "ccr_depa_covid_poc_dp_data_prep_mnist_2.py"]
   mnist_3:
-    image: ${CONTAINER_REGISTRY}/preprocess-mnist_3:latest
+    image: ${CONTAINER_REGISTRY:+$CONTAINER_REGISTRY/}preprocess-mnist_3:latest
     volumes:
       - $MNIST_3_INPUT_PATH:/mnt/depa_ccr_poc/data
       - $MNIST_3_OUTPUT_PATH:/mnt/output/mnist_3

--- a/scenarios/mnist/deployment/docker/docker-compose-train.yml
+++ b/scenarios/mnist/deployment/docker/docker-compose-train.yml
@@ -1,6 +1,6 @@
 services:
   train:
-    image: ${CONTAINER_REGISTRY}/depa-training:latest
+    image: ${CONTAINER_REGISTRY:+$CONTAINER_REGISTRY/}depa-training:latest
     volumes:
       - $MNIST_1_INPUT_PATH:/mnt/remote/mnist_1
       - $MNIST_2_INPUT_PATH:/mnt/remote/mnist_2

--- a/scenarios/mnist/src/ccr_depa_covid_poc_dp_data_prep_mnist_1.py
+++ b/scenarios/mnist/src/ccr_depa_covid_poc_dp_data_prep_mnist_1.py
@@ -27,7 +27,7 @@ debug_poc=True
 model_input_folder='/mnt/depa_ccr_poc/data/'
 
 # POC State-wise dummy data
-mnist_1_file ='poc_mnist_1_data.csv'
+mnist_1_file ='poc_data_mnist_1_data.csv'
 
 # Used for loading/Process at DP (Ideally done at DP, we just pick up anonymised/tokenised datasets)
 load_process_dp_data=True

--- a/scenarios/mnist/src/ccr_depa_covid_poc_dp_data_prep_mnist_2.py
+++ b/scenarios/mnist/src/ccr_depa_covid_poc_dp_data_prep_mnist_2.py
@@ -27,7 +27,7 @@ debug_poc=True
 model_input_folder='/mnt/depa_ccr_poc/data/'
 
 # POC State-wise dummy data
-mnist_2_file ='poc_mnist_2_data.csv'
+mnist_2_file ='poc_data_mnist_2_data.csv'
 
 # Used for loading/Process at DP (Ideally done at DP, we just pick up anonymised/tokenised datasets)
 load_process_dp_data=True

--- a/scenarios/mnist/src/ccr_depa_covid_poc_dp_data_prep_mnist_3.py
+++ b/scenarios/mnist/src/ccr_depa_covid_poc_dp_data_prep_mnist_3.py
@@ -27,7 +27,7 @@ debug_poc=True
 model_input_folder='/mnt/depa_ccr_poc/data/'
 
 # POC State-wise dummy data
-mnist_3_file ='poc_mnist_3_data.csv'
+mnist_3_file ='poc_data_mnist_3_data.csv'
 
 # Used for loading/Process at DP (Ideally done at DP, we just pick up anonymised/tokenised datasets)
 load_process_dp_data=True


### PR DESCRIPTION


The following error remains during training

docker-train-1  |     main()
docker-train-1  |   File "//ccr_train.py", line 183, in main
docker-train-1  |     ccr_private_model.ccr_model_run()
docker-train-1  |   File "//ccr_train.py", line 159, in ccr_model_run
docker-train-1  |     self.execute_model()
docker-train-1  |   File "//ccr_train.py", line 144, in execute_model
docker-train-1  |     outputs = self.model(inputs)
docker-train-1  |   File "/usr/local/lib/python3.9/dist-packages/torch/nn/modules/module.py", line 1538, in _call_impl
docker-train-1  |     result = forward_call(*args, **kwargs)
docker-train-1  |   File "/usr/local/lib/python3.9/dist-packages/opacus/grad_sample/grad_sample_module.py", line 148, in forward
docker-train-1  |     return self._module(*args, **kwargs)
docker-train-1  |   File "/usr/local/lib/python3.9/dist-packages/torch/nn/modules/module.py", line 1501, in _call_impl
docker-train-1  |     return forward_call(*args, **kwargs)
docker-train-1  |   File "/usr/local/lib/python3.9/dist-packages/onnx2pytorch/convert/model.py", line 224, in forward
docker-train-1  |     activations[out_op_id] = op(*in_activations)
docker-train-1  |   File "/usr/local/lib/python3.9/dist-packages/torch/nn/modules/module.py", line 1538, in _call_impl
docker-train-1  |     result = forward_call(*args, **kwargs)
docker-train-1  |   File "/usr/local/lib/python3.9/dist-packages/torch/nn/modules/linear.py", line 114, in forward
docker-train-1  |     return F.linear(input, self.weight, self.bias)
docker-train-1  | RuntimeError: mat1 and mat2 shapes cannot be multiplied (4x785 and 10x128)